### PR TITLE
feat: remove automat biolink from API_LIST

### DIFF
--- a/src/config/apis.js
+++ b/src/config/apis.js
@@ -182,12 +182,6 @@ exports.API_LIST = {
     // Notes: We don't ingest the following:
     // - Automat-robokop: seems to repeat a lot of data that is in the other APIs
     {
-      // this API overlaps with our Biolink API registration, but we have bugs with our api-response-transform
-      //   this may have been updated more recently / transformed data into TRAPI format
-      id: "ef0656900ff73f861611bcad87a94bce",
-      name: "Automat-biolink(Trapi v1.4.0)",
-    },
-    {
       // this may overlap with info we have in MyDisease, MyChem, and other APIs...
       id: "97da45e75266b021fae885735befad07",
       name: "Automat-ctd(Trapi v1.4.0)",


### PR DESCRIPTION
The automat team removed the smartapi registration for automat biolink...While it doesn't cause issues for BTE, it'll be good to remove this outdated entry. 

UPDATE: the future "automat monarch-kg" API should include the "automat biolink" data plus extra ([Translator Slack link](https://ncatstranslator.slack.com/archives/C013Q5TVC87/p1704496676656039?thread_ts=1704306565.182029&cid=C013Q5TVC87)). I see automat monarch-kg in their [dev (renci) instance](https://automat.renci.org/) but not in smartapi registry yet

Reference: [Translator Slack convo](https://ncatstranslator.slack.com/archives/C013Q5TVC87/p1704306565182029)
* use SmartAPI registry to find the current list of KPs (search "automat")
* their [dev instance](https://automat.renci.org/) is also helpful, but may have KPs that aren't registered yet
* we aren't using all of their non-robokop KPs....perhaps we could do a review of them sometime to decide which ones to add. But in our convo, it sounds like they're still in the process of adding/deploying them... 