### PR TITLE
feat: use trapi 1.5 chp registration in api list

### DIFF
--- a/config/api_list.yaml
+++ b/config/api_list.yaml
@@ -145,6 +145,6 @@ include:
     name: COHD TRAPI
   # TRAPI (Translator standard) APIs: CHP
   # not accessible by team or api-specific endpoints
-  - id: 23f770568b92b7a82063989b3ddd9706
+  - id: 412af63e15b73e5a30778aac84ce313f
     name: Connections Hypothesis Provider API
 exclude: [] # if adding exclude remove these square brackets


### PR DESCRIPTION
For https://github.com/biothings/biothings_explorer/issues/817#issuecomment-2093578967. 

Maybe wait?

Right now, the CHP registration has dev/CI instances (see https://arax.ncats.io/ -> SmartAPI Info). 
But we don't want to add this to Test until the registration has the test instance as well...