### PR TITLE
Post-Octopus chore: remove temporary changes

### DIFF
--- a/config/smartapi_exclusions.yaml
+++ b/config/smartapi_exclusions.yaml
@@ -3,8 +3,3 @@
   name: BioThings Explorer (BTE) TRAPI
 - id: 36f82f05705c317bac17ddae3a0ea2f0
   name: Service Provider TRAPI
-## temp separate registrations for TRAPI 1.5
-- id: 8d97ee37572eaaf9e74df447763fd0c5
-  name: BioThings Explorer (BTE) TRAPI
-- id: a0595049c9a250003c2eced0946d84f6
-  name: Service Provider TRAPI

--- a/config/smartapi_overrides.yaml
+++ b/config/smartapi_overrides.yaml
@@ -2,7 +2,6 @@
 config:
   only_overrides: false
 apis:
-    978fe380a147a8641caf72320862697b: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/treats-refactor-tmkp/text_mining/smartapi.yaml
     38e9e5169a72aee3659c9ddba956790d: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/source_record_urls/bindingdb/smartapi.yaml
     edeb26858bd27d0322af93e7a9e08761: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/source_record_urls/pfocr/smartapi.yaml
     59dce17363dce279d389100834e43648: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/source_record_urls/mygene.info/openapi_full.yml

--- a/config/smartapi_overrides.yaml
+++ b/config/smartapi_overrides.yaml
@@ -1,4 +1,4 @@
 ---
 config:
   only_overrides: false
-apis:
+apis: []

--- a/config/smartapi_overrides.yaml
+++ b/config/smartapi_overrides.yaml
@@ -2,6 +2,3 @@
 config:
   only_overrides: false
 apis:
-    38e9e5169a72aee3659c9ddba956790d: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/source_record_urls/bindingdb/smartapi.yaml
-    edeb26858bd27d0322af93e7a9e08761: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/source_record_urls/pfocr/smartapi.yaml
-    59dce17363dce279d389100834e43648: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/source_record_urls/mygene.info/openapi_full.yml

--- a/config/smartapi_overrides.yaml
+++ b/config/smartapi_overrides.yaml
@@ -2,12 +2,6 @@
 config:
   only_overrides: false
 apis:
-    32f36164fabed5d3abe6c2fd899c9418: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/biolink-4-update/idisk/smartapi.yaml
-    b48c34df08d16311e3bca06b135b828d: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/biolink-4-update/suppkg/suppkg.yaml
-    e481efd21f8e8c1deac05662439c2294: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/biolink-4-update/ttd/smartapi.yaml
-    1d288b3a3caf75d541ffaae3aab386c8: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/biolink-4-update/semmeddb/smartapi.yaml
-    8f08d1446e0bb9c2b323713ce83e2bd3: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/biolink-4-update/mychem.info/openapi_full.yml
-    1138c3297e8e403b6ac10cff5609b319: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/biolink-4-update/repodb/smartapi.yaml
     978fe380a147a8641caf72320862697b: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/treats-refactor-tmkp/text_mining/smartapi.yaml
     38e9e5169a72aee3659c9ddba956790d: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/source_record_urls/bindingdb/smartapi.yaml
     edeb26858bd27d0322af93e7a9e08761: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/source_record_urls/pfocr/smartapi.yaml


### PR DESCRIPTION
For the Octopus patch and https://github.com/biothings/biothings_explorer/issues/811

@tokebe, does the smartapi overrides yaml look okay? Does it work correctly with the smartapi_sync cron job? 

I don't often write empty objects (`apis`). 
And I tried manually triggering smartapi_sync locally with API_OVERRIDE=true, and I get a console log saying the update failed, which is maybe correct behavior...