### PR TITLE
Revert "chore: update biolink-model version"

### DIFF
--- a/docs/smartapi.yaml
+++ b/docs/smartapi.yaml
@@ -12,10 +12,10 @@ info:
     component: ARA
     team:
       - Exploring Agent
-    biolink-version: "4.2.2"
+    biolink-version: "4.1.6"
     infores: "infores:biothings-explorer"
   x-trapi:
-    version: 1.5.0
+    version: "1.5.0"
     multicuriequery: false
     pathfinderquery: true  ## dev instance only
     asyncquery: true


### PR DESCRIPTION
Reverts biothings/bte-server#34

Supposed to be post-patch.