### PR TITLE
Re-enable CTKP with `includeFlipped` set

### DIFF
--- a/config/api_list.yaml
+++ b/config/api_list.yaml
@@ -147,6 +147,7 @@ include:
     name: Connections Hypothesis Provider API
   # # TRAPI (Translator standard) APIs: Multiomics (made with RTX team Plover)
   # # not accessible by team or api-specific endpoints
-  # - id: e51073371d7049b9643e1edbdd61bcbd
-  #   name: Clinical Trials KP - TRAPI 1.5.0
+  - id: e51073371d7049b9643e1edbdd61bcbd
+    name: Clinical Trials KP - TRAPI 1.5.0
+    includeFlipped: true
 exclude: [] # if adding exclude remove these square brackets

--- a/config/api_list.yaml
+++ b/config/api_list.yaml
@@ -122,10 +122,10 @@ include:
   # not accessible by team or api-specific endpoints
   - id: 1901bab8d33bb70b124f400ec1cfdba3
     name: MolePro
-  # # TRAPI (Translator standard) APIs: Multiomics (made with RTX team Plover)
-  # # not accessible by team or api-specific endpoints
-  # - id: e51073371d7049b9643e1edbdd61bcbd
-  #   name: Clinical Trials KP - TRAPI 1.5.0
+  # TRAPI (Translator standard) APIs: Multiomics (made with RTX team Plover)
+  # not accessible by team or api-specific endpoints
+  - id: e51073371d7049b9643e1edbdd61bcbd
+    name: Clinical Trials KP - TRAPI 1.5.0
   - id: edc04feaf16c12424737988ce2e90d60
     name: Drug Approvals KP - TRAPI 1.5.0
   - id: a8be4ea3fe8fa80a952ead0b3c5e4bc1

--- a/config/api_list.yaml
+++ b/config/api_list.yaml
@@ -126,6 +126,8 @@ include:
   # # not accessible by team or api-specific endpoints
   # - id: e51073371d7049b9643e1edbdd61bcbd
   #   name: Clinical Trials KP - TRAPI 1.5.0
+  - id: edc04feaf16c12424737988ce2e90d60
+    name: Drug Approvals KP - TRAPI 1.5.0
   - id: a8be4ea3fe8fa80a952ead0b3c5e4bc1
     name: Microbiome KP - TRAPI 1.5.0
   - id: 1b6de23ed3c4e0713b20794477ba1e39

--- a/config/api_list.yaml
+++ b/config/api_list.yaml
@@ -102,36 +102,9 @@ include:
     name: Text Mining Targeted Association API
   # TRAPI (Translator standard) APIs: Automat
   # not accessible by team or api-specific endpoints
-  # Notes: We don't ingest the following:
-  # - Automat-robokop: seems to repeat a lot of data that is in the other APIs
-  - id: f82c01b15c46e024212c1a3271aaef0b
-    name: Automat-ctd(Trapi v1.5.0)
-  - id: 673b9fc76973dfa5fe3ed151fdbfc807
-    name: Automat-drug-central(Trapi v1.5.0)
-  - id: eef72049e4e01c020b7799f711e0e65b
-    name: Automat-gtex(Trapi v1.5.0)
-  - id: 759df287a21c30cd514df323be02a84b
-    name: Automat-gtopdb(Trapi v1.5.0)
-  - id: 349fed5531c094c33f10c071efe9d0de
-    name: Automat-gwas-catalog(Trapi v1.5.0)
-  - id: a5fe24f987331b58191e67598118f369
-    name: Automat-hetionet(Trapi v1.5.0)
-  - id: 8671309d2b94e413a4c1f9a9f82e4660
-    name: Automat-hgnc(Trapi v1.5.0)
-  - id: 0a1c0f46f4950b82b1aa7dad27aad10a
-    name: Automat-hmdb(Trapi v1.5.0)
-  - id: cb7a43d444cb3dcbe8e3c78d314334cf
-    name: Automat-human-goa(Trapi v1.5.0)
-  - id: c64d583402f21cc85810d33befe49c86
-    name: Automat-icees-kg(Trapi v1.5.0)
-  - id: b4023595664163e0aec5e825da150e16
-    name: Automat-intact(Trapi v1.5.0)
-  - id: 3f78d3fb8a7a577fbc7cc0a913ac3fc5
-    name: Automat-panther(Trapi v1.5.0)
-  - id: 1f057c53d42694686369f0e542f965c6
-    name: Automat-pharos(Trapi v1.5.0)
-  - id: 2aca41fc6c3dc426ec6583d42603be02
-    name: Automat-viral-proteome(Trapi v1.5.0)
+  # using robokop to access all automat resources at once
+  - id: 4f9c8853b721ef1f14ecee6d92fc19b5
+    name: Automat-robokop(Trapi v1.5.0)
   # TRAPI (Translator standard) APIs: COHD
   # not accessible by team or api-specific endpoints
   # notes on COHD:
@@ -145,8 +118,16 @@ include:
   # not accessible by team or api-specific endpoints
   - id: 412af63e15b73e5a30778aac84ce313f
     name: Connections Hypothesis Provider API
+  # TRAPI (Translator standard) APIs: Molecular Data Provider
+  # not accessible by team or api-specific endpoints
+  - id: 1901bab8d33bb70b124f400ec1cfdba3
+    name: MolePro
   # # TRAPI (Translator standard) APIs: Multiomics (made with RTX team Plover)
   # # not accessible by team or api-specific endpoints
   # - id: e51073371d7049b9643e1edbdd61bcbd
   #   name: Clinical Trials KP - TRAPI 1.5.0
+  - id: a8be4ea3fe8fa80a952ead0b3c5e4bc1
+    name: Microbiome KP - TRAPI 1.5.0
+  - id: 1b6de23ed3c4e0713b20794477ba1e39
+    name: Multiomics KP - TRAPI 1.5.0
 exclude: [] # if adding exclude remove these square brackets

--- a/config/smartapi_overrides.yaml
+++ b/config/smartapi_overrides.yaml
@@ -2,6 +2,6 @@
 config:
   only_overrides: false
 apis: {
-  # "8f08d1446e0bb9c2b323713ce83e2bd3": "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/refs/heads/remove-clinical-trials/mychem.info/openapi_full.yml",
-  # "1138c3297e8e403b6ac10cff5609b319": "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/refs/heads/remove-clinical-trials/repodb/smartapi.yaml"
+  "8f08d1446e0bb9c2b323713ce83e2bd3": "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/refs/heads/remove-clinical-trials/mychem.info/openapi_full.yml",
+  "1138c3297e8e403b6ac10cff5609b319": "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/refs/heads/remove-clinical-trials/repodb/smartapi.yaml"
 }


### PR DESCRIPTION
Part of reverse-metaEdge injection support for https://github.com/biothings/biothings_explorer/issues/861