### PR TITLE
chore: add override for semmeddb

### DIFF
--- a/config/smartapi_overrides.yaml
+++ b/config/smartapi_overrides.yaml
@@ -2,6 +2,7 @@
 config:
   only_overrides: false
 apis: {
+  "1d288b3a3caf75d541ffaae3aab386c8": "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/refs/heads/semmeddb_publication_refactor/semmeddb/smartapi.yaml"
   # "8f08d1446e0bb9c2b323713ce83e2bd3": "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/refs/heads/remove-clinical-trials/mychem.info/openapi_full.yml",
   # "1138c3297e8e403b6ac10cff5609b319": "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/refs/heads/remove-clinical-trials/repodb/smartapi.yaml"
 }


### PR DESCRIPTION
for https://github.com/biothings/biothings_explorer/issues/833
goes with https://github.com/biothings/api-respone-transform.js/pull/68, so DON'T MERGE until the api-response-transform PR is done and ready. 

has adjusted x-bte annotation to use the new semmeddb-edge-attribute feature

