### PR TITLE
Remove MolePro from use

### DIFF
--- a/config/api_list.yaml
+++ b/config/api_list.yaml
@@ -126,10 +126,14 @@ include:
   # not accessible by team or api-specific endpoints
   - id: e51073371d7049b9643e1edbdd61bcbd
     name: Clinical Trials KP - TRAPI 1.5.0
+    includeFlipped: true
   - id: edc04feaf16c12424737988ce2e90d60
     name: Drug Approvals KP - TRAPI 1.5.0
+    includeFlipped: true
   - id: a8be4ea3fe8fa80a952ead0b3c5e4bc1
     name: Microbiome KP - TRAPI 1.5.0
+    includeFlipped: true
   - id: 1b6de23ed3c4e0713b20794477ba1e39
     name: Multiomics KP - TRAPI 1.5.0
+    includeFlipped: true
 exclude: [] # if adding exclude remove these square brackets

--- a/config/api_list.yaml
+++ b/config/api_list.yaml
@@ -118,10 +118,6 @@ include:
   # not accessible by team or api-specific endpoints
   - id: 412af63e15b73e5a30778aac84ce313f
     name: Connections Hypothesis Provider API
-  # TRAPI (Translator standard) APIs: Molecular Data Provider
-  # not accessible by team or api-specific endpoints
-  - id: 1901bab8d33bb70b124f400ec1cfdba3
-    name: MolePro
   # TRAPI (Translator standard) APIs: Multiomics (made with RTX team Plover)
   # not accessible by team or api-specific endpoints
   - id: e51073371d7049b9643e1edbdd61bcbd


### PR DESCRIPTION
Related to https://github.com/biothings/biothings_explorer/issues/865

Given urgent issues with BTE timeouts: going to remove MolePro. 

Queries to it timeout often, and adds wait time. And we may be querying it more with the record limit, parallel features. 