### PR TITLE
try out: use individual automats, remove use of drug approvals

### DIFF
--- a/config/api_list.yaml
+++ b/config/api_list.yaml
@@ -102,9 +102,36 @@ include:
     name: Text Mining Targeted Association API
   # TRAPI (Translator standard) APIs: Automat
   # not accessible by team or api-specific endpoints
-  # using robokop to access all automat resources at once
-  - id: 4f9c8853b721ef1f14ecee6d92fc19b5
-    name: Automat-robokop(Trapi v1.5.0)
+  # Notes: We don't ingest the following:
+  # - Automat-robokop: seems to repeat a lot of data that is in the other APIs
+  - id: f82c01b15c46e024212c1a3271aaef0b
+    name: Automat-ctd(Trapi v1.5.0)
+  - id: 673b9fc76973dfa5fe3ed151fdbfc807
+    name: Automat-drug-central(Trapi v1.5.0)
+  - id: eef72049e4e01c020b7799f711e0e65b
+    name: Automat-gtex(Trapi v1.5.0)
+  - id: 759df287a21c30cd514df323be02a84b
+    name: Automat-gtopdb(Trapi v1.5.0)
+  - id: 349fed5531c094c33f10c071efe9d0de
+    name: Automat-gwas-catalog(Trapi v1.5.0)
+  - id: a5fe24f987331b58191e67598118f369
+    name: Automat-hetionet(Trapi v1.5.0)
+  - id: 8671309d2b94e413a4c1f9a9f82e4660
+    name: Automat-hgnc(Trapi v1.5.0)
+  - id: 0a1c0f46f4950b82b1aa7dad27aad10a
+    name: Automat-hmdb(Trapi v1.5.0)
+  - id: cb7a43d444cb3dcbe8e3c78d314334cf
+    name: Automat-human-goa(Trapi v1.5.0)
+  - id: c64d583402f21cc85810d33befe49c86
+    name: Automat-icees-kg(Trapi v1.5.0)
+  - id: b4023595664163e0aec5e825da150e16
+    name: Automat-intact(Trapi v1.5.0)
+  - id: 3f78d3fb8a7a577fbc7cc0a913ac3fc5
+    name: Automat-panther(Trapi v1.5.0)
+  - id: 1f057c53d42694686369f0e542f965c6
+    name: Automat-pharos(Trapi v1.5.0)
+  - id: 2aca41fc6c3dc426ec6583d42603be02
+    name: Automat-viral-proteome(Trapi v1.5.0)
   # TRAPI (Translator standard) APIs: COHD
   # not accessible by team or api-specific endpoints
   # notes on COHD:
@@ -122,9 +149,6 @@ include:
   # not accessible by team or api-specific endpoints
   - id: e51073371d7049b9643e1edbdd61bcbd
     name: Clinical Trials KP - TRAPI 1.5.0
-    includeFlipped: true
-  - id: edc04feaf16c12424737988ce2e90d60
-    name: Drug Approvals KP - TRAPI 1.5.0
     includeFlipped: true
   - id: a8be4ea3fe8fa80a952ead0b3c5e4bc1
     name: Microbiome KP - TRAPI 1.5.0


### PR DESCRIPTION
Copied from [Slack](https://suwulab.slack.com/archives/CC218TEKC/p1730342302126729):


> [Here's my analysis](https://docs.google.com/document/d/1FKtET-GjbC0-8FX3DeMRhtYlHUmuYNdSZc6pNuarpFM/edit?usp=sharing) of how the "new TRAPI KP additions" are affecting BTE's automated test harness performance.
> My recommendations: try adjusting BTE-CI's API_LIST https://github.com/biothings/bte-server/pull/52
> - Try using the old set of individual Automat APIs
> - Remove use of Multiomics Drug Approvals
> See how it does in this weekend's automated test run. If the tests I identified pass + number of TopAnswer passes is improved, then consider putting it into the hotfix CI->Test deployment.
> Caveat: I didn't have time to dig into the biology/content of the answers. 